### PR TITLE
ci: release crates with `release-plz`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+permissions:
+  pull-requests: write
+  contents: write
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # release-plz can create release notes and update changelogs based on (conventional) commits. But only if all the history is fetched
+          fetch-depth: 0
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Define a release workflow to publish crates with [`release-plz`](https://release-plz.ieni.dev/).  
It is a tool recommended by the [official rust docs](https://doc.rust-lang.org/cargo/reference/publishing.html#publishing-a-new-version-of-an-existing-crate) that has lot of nice features: CLI, updating changelog, bump versions according to conventional commits, create release notes...
