### PR TITLE
chore: generate coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install cargo-nextest
-        uses: taiki-e/cache-cargo-install-action@v2.0.1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.3
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2.42.0
         with:
-          tool: cargo-nextest
-      - run: cargo nextest run
+          tool: cargo-llvm-cov
+      - name: Run tests with coverage report
+        run: cargo llvm-cov --all-features --all-targets --lcov --workspace --output-path lcov.info
+      - name: Upload test coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov.info
+          path: lcov.info
+
+  coverage:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: lcov.info
+          path: .
+      - uses: coverallsapp/github-action@v2.3.0
+        with:
+          base-path: /
+          file: lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.setup.sh
+++ b/.setup.sh
@@ -38,7 +38,7 @@ maybe_install_local() {
 
 install_dev_deps() {
   log "Installing development dependencies..."
-  crates="convco dprint cargo-nextest"
+  crates="convco dprint cargo-llvm-cov cargo-nextest"
 
   for crate in $crates; do
     maybe_install_local "$crate"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CYAN := \033[36m
 RESET := \033[0m
 PATH := $(DEV_BIN_DIR):$(PATH)
 
-.PHONY: help build build.docs fix fmt lint setup test
+.PHONY: help build build.docs check commit coverage docs fix fmt lint setup test
 
 help: ## display this help message (default task)
 	@printf "%b\n" "Usage: make [$(CYAN)task$(RESET)]"
@@ -25,6 +25,9 @@ check: ## check that all files match formatting rules
 commit: ## make conventional commit
 	@PATH=$(PATH) convco commit
 
+coverage: ## generate coverage report
+	@PATH=$(PATH) cargo llvm-cov --all-features report
+
 docs: ## build & open the documentation in the browser
 	@cargo doc --no-deps --open --all-features
 
@@ -41,4 +44,4 @@ setup: ## run the setup script to install dependencies
 	@./.setup.sh
 
 test: ## run all tests
-	@cargo-nextest ntr
+	@cargo-nextest ntr --all-features --all-targets --workspace


### PR DESCRIPTION
- Add a `coverage` make task to generate a coverage report to STDOUT
- Generate a coverage `lcov.info` report when running the tests in the CI and upload that to coveralls

Closes #43