### PR TITLE
ci: checkout before reporting coverage to coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: lcov.info


### PR DESCRIPTION
I had deliberately ommitted the checkout step in the coverage job in #46  because I thought it was sufficient for `coveralls` to only have a coverage report file (`lcov.info`) in order to be able to report the coverage.  
But it is not, it needs to read the src files too, otherwise it fails with a [`nothing to report` error](https://github.com/privacy-scaling-explorations/zk-kit.rust/actions/runs/10300402250/job/28509727109#step:3:60).  
So we need to checkout.

The [coverage job execution on this test branch](https://github.com/privacy-scaling-explorations/zk-kit.rust/actions/runs/10301338228/job/28512666893?pr=48#step:4:62) demonstrated that the fix is effective.