### PR TITLE
chore(imt): Add methods to retrieve nodes and zeroes in IMT

### DIFF
--- a/crates/imt/src/imt.rs
+++ b/crates/imt/src/imt.rs
@@ -73,6 +73,14 @@ impl IMT {
         self.depth
     }
 
+    pub fn nodes(&self) -> Vec<Vec<IMTNode>> {
+        self.nodes.clone()
+    }
+
+    pub fn zeroes(&self) -> Vec<IMTNode> {
+        self.zeroes.clone()
+    }
+
     pub fn leaves(&self) -> Vec<IMTNode> {
         self.nodes[0].clone()
     }


### PR DESCRIPTION
## Description

The code changes introduce two new getter methods, `nodes()` and `zeroes()`, to the IMT struct. These methods are necessary for accessing the internal structure of the IMT, particularly for cases where the intermediate tree states and padding values are required.

The `nodes()` method provides access to the current state of the tree's nodes, which is useful for debugging and verifying the structure of the Merkle tree during construction.

The `zeroes()` method allows retrieval of the precomputed zero nodes, which are critical for correctly padding incomplete levels when combining batch roots in parallel Merkle tree construction.

## Other Information 
I needed access to the zeroes without re-generating them, and the intermediate nodes are useful for debugging during parallelization.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
