### PR TITLE
ci: add `release-plz` config file

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+release_always = false


### PR DESCRIPTION
Attempt to address https://github.com/privacy-scaling-explorations/zk-kit.rust/pull/55#issuecomment-2385639067

Maybe what happened is:
1. PR merges, `release_always` is by default true so the `release-plz` CLI runs
  1. `release-pr` command (`update` command AND opening of PR): it tries to update but failed (e.g. no pkg on crates.io and no CHANGELOG file yet, see https://github.com/privacy-scaling-explorations/zk-kit.rust/actions/runs/11124754559/job/30910962049#step:4:230). A PR is opened nonetheless. 
  2. `release` command: runs nonetheless, new crate is published
2. we merge the release PR created by the previous release GH workflow (previous step)
3.  In the next release workflow run, the `release-pr` step that includes the `update` command detects a new commit (the PR merge at step 1) and bumps the version again, creating a new PR too.

A fix could be to set [`release_always`](https://release-plz.ieni.dev/docs/config#the-release_always-field) to `false`.
