### PR TITLE
Add missing `index_of()` fn

### DIFF
--- a/crates/imt/src/imt.rs
+++ b/crates/imt/src/imt.rs
@@ -89,6 +89,10 @@ impl IMT {
         self.arity
     }
 
+    pub fn index_of(&self, leaf: IMTNode) -> Option<usize> {
+        self.nodes.get(0)?.iter().position(|n| n == &leaf)
+    }
+
     pub fn insert(&mut self, leaf: IMTNode) -> Result<(), &'static str> {
         if self.nodes[0].len() >= self.arity.pow(self.depth as u32) {
             return Err("The tree is full");
@@ -321,5 +325,22 @@ mod tests {
 
         assert_eq!(imt.depth(), 3);
         assert_eq!(imt.arity(), 2);
+    }
+
+    #[test]
+    fn test_index_of() {
+        let hash: IMTHashFunction = simple_hash_function;
+        let imt = IMT::new(
+            hash,
+            2,
+            "zero".to_string(),
+            2,
+            vec!["leaf1".to_string(), "leaf2".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(imt.index_of("leaf1".to_string()), Some(0));
+        assert_eq!(imt.index_of("leaf2".to_string()), Some(1));
+        assert_eq!(imt.index_of("leaf3".to_string()), None);
     }
 }


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR aims to add an `index_of()` fn to `IMT` impl to mirror the TS implementation. The function takes a `leaf` and returns an `Option<usize>` that evaluate to `Some(idx)` where `idx` is the index of the `leaf` or `None` when the `leaf` does not exists in the `IMT`.

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.rust/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.rust/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `yarn style` without getting any errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
