### PR TITLE
feat: nodes accessor for `lean-imt`

### DIFF
--- a/crates/lean-imt/src/lean_imt.rs
+++ b/crates/lean-imt/src/lean_imt.rs
@@ -268,6 +268,11 @@ impl<const N: usize> LeanIMT<N> {
             .ok_or(LeanIMTError::IndexOutOfBounds)
     }
 
+    /// Returns the internal nodes structure.
+    pub fn nodes(&self) -> &[Vec<[u8; N]>] {
+        &self.nodes
+    }
+
     /// Retrieves the node at a specified level and index.
     pub fn get_node(&self, level: usize, index: usize) -> Result<[u8; N], LeanIMTError> {
         let level_vec = self

--- a/crates/lean-imt/src/lean_imt.rs
+++ b/crates/lean-imt/src/lean_imt.rs
@@ -3,7 +3,9 @@
 //! Lean Incremental Merkle Tree implementation.
 //!
 //! Specifications can be found here:
-//!  - https://github.com/privacy-scaling-explorations/zk-kit/blob/main/papers/leanimt/paper/leanimt-paper.pdf
+//!  - <https://github.com/privacy-scaling-explorations/zk-kit/blob/main/papers/leanimt/paper/leanimt-paper.pdf>
+
+#![allow(clippy::manual_div_ceil)]
 
 use thiserror::Error;
 

--- a/crates/lean-imt/src/lib.rs
+++ b/crates/lean-imt/src/lib.rs
@@ -30,19 +30,17 @@
 //!     }
 //! }
 //!
-//! fn main() {
-//!     let mut tree = HashedLeanIMT::<32, SampleHasher>::new(&[], SampleHasher).unwrap();
+//! let mut tree = HashedLeanIMT::<32, SampleHasher>::new(&[], SampleHasher).unwrap();
 //!
-//!     tree.insert(&[1; 32]);
-//!     tree.insert(&[2; 32]);
-//!     tree.insert_many(&[[3; 32], [4; 32], [5; 32]]);
+//! tree.insert(&[1; 32]);
+//! tree.insert(&[2; 32]);
+//! tree.insert_many(&[[3; 32], [4; 32], [5; 32]]);
 //!
-//!     println!("Tree root: {:?}", tree.root().unwrap());
-//!     println!("Tree depth: {}", tree.depth());
+//! println!("Tree root: {:?}", tree.root().unwrap());
+//! println!("Tree depth: {}", tree.depth());
 //!
-//!     let proof = tree.generate_proof(3).unwrap();
-//!     assert!(HashedLeanIMT::<32, SampleHasher>::verify_proof(&proof));
-//! }
+//! let proof = tree.generate_proof(3).unwrap();
+//! assert!(HashedLeanIMT::<32, SampleHasher>::verify_proof(&proof));
 //! ```
 
 pub mod hashed_tree;


### PR DESCRIPTION
## Description

This PR adds a `nodes` method to the `LeanIMT` struct, exposing the internal nodes structure as a slice (`&[Vec<[u8; N]>]`). 

It also fixes minor clippy warnings by allowing `manual_div_ceil` and reformat the example in `lib.rs`.

- **What kind of change?** Feature addition
- **Current behavior**: No method exists to access the internal nodes structure of `LeanIMT`.
- **New behavior**: The `nodes` method returns a reference to the internal nodes, allowing read-only access.
- **Breaking change?** No.

## Related Issue(s)

Resolves #76 

## Other information

The change is minimal and does not affect existing functionality. No new tests were added as the method is a simple accessor, but existing tests pass.

## Checklist

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.rust/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.rust/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have run `cargo fmt` without getting any errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.