### PR TITLE
Introduce consistent typed error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,18 +453,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -563,6 +563,7 @@ name = "zk-kit-imt"
 version = "0.0.7"
 dependencies = [
  "hex",
+ "thiserror",
  "tiny-keccak",
 ]
 
@@ -592,4 +593,5 @@ name = "zk-kit-smt"
 version = "0.0.7"
 dependencies = [
  "num-bigint",
+ "thiserror",
 ]

--- a/crates/imt/Cargo.toml
+++ b/crates/imt/Cargo.toml
@@ -8,4 +8,5 @@ description = "Incremental Merkle Tree"
 
 [dependencies]
 hex = "0.4.3"
+thiserror = "2"
 tiny-keccak = { version = "2.0.0", features = ["keccak"] }

--- a/crates/imt/src/errors.rs
+++ b/crates/imt/src/errors.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum ImtError {
+    #[error("Too many leaves: got {got}, max for arity {arity} and depth {depth} is max {max}")]
+    TooManyLeaves {
+        got: usize,
+        arity: usize,
+        depth: usize,
+        max: usize,
+    },
+    #[error("The tree is full")]
+    TreeFull,
+    #[error("The leaf does not exist in this tree")]
+    NotContained,
+}

--- a/crates/imt/src/imt.rs
+++ b/crates/imt/src/imt.rs
@@ -1,3 +1,5 @@
+use crate::errors::ImtError;
+
 pub struct IMT {
     nodes: Vec<Vec<IMTNode>>,
     zeroes: Vec<IMTNode>,
@@ -23,9 +25,16 @@ impl IMT {
         zero_value: IMTNode,
         arity: usize,
         leaves: Vec<IMTNode>,
-    ) -> Result<IMT, &'static str> {
-        if leaves.len() > arity.pow(depth as u32) {
-            return Err("The tree cannot contain more than arity^depth leaves");
+    ) -> Result<IMT, ImtError> {
+        let got = leaves.len();
+        let max = arity.pow(depth as u32);
+        if got > max {
+            return Err(ImtError::TooManyLeaves {
+                got,
+                arity,
+                depth,
+                max,
+            });
         }
 
         let mut imt = IMT {
@@ -93,9 +102,9 @@ impl IMT {
         self.nodes.get(0)?.iter().position(|n| n == &leaf)
     }
 
-    pub fn insert(&mut self, leaf: IMTNode) -> Result<(), &'static str> {
+    pub fn insert(&mut self, leaf: IMTNode) -> Result<(), ImtError> {
         if self.nodes[0].len() >= self.arity.pow(self.depth as u32) {
-            return Err("The tree is full");
+            return Err(ImtError::TreeFull);
         }
 
         let index = self.nodes[0].len();
@@ -103,9 +112,9 @@ impl IMT {
         self.update(index, self.nodes[0][index].clone())
     }
 
-    pub fn update(&mut self, mut index: usize, new_leaf: IMTNode) -> Result<(), &'static str> {
+    pub fn update(&mut self, mut index: usize, new_leaf: IMTNode) -> Result<(), ImtError> {
         if index >= self.nodes[0].len() {
-            return Err("The leaf does not exist in this tree");
+            return Err(ImtError::NotContained);
         }
 
         let mut node = new_leaf;
@@ -138,13 +147,13 @@ impl IMT {
         Ok(())
     }
 
-    pub fn delete(&mut self, index: usize) -> Result<(), &'static str> {
+    pub fn delete(&mut self, index: usize) -> Result<(), ImtError> {
         self.update(index, self.zeroes[0].clone())
     }
 
-    pub fn create_proof(&self, index: usize) -> Result<IMTMerkleProof, &'static str> {
+    pub fn create_proof(&self, index: usize) -> Result<IMTMerkleProof, ImtError> {
         if index >= self.nodes[0].len() {
-            return Err("The leaf does not exist in this tree");
+            return Err(ImtError::NotContained);
         }
 
         let mut siblings = Vec::with_capacity(self.depth);

--- a/crates/imt/src/lib.rs
+++ b/crates/imt/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod errors;
 pub mod hash;
 pub mod imt;
+
+pub use errors::ImtError;

--- a/crates/smt/Cargo.toml
+++ b/crates/smt/Cargo.toml
@@ -10,3 +10,4 @@ description = "Sparse Merkle Tree"
 
 [dependencies]
 num-bigint = "0.4.6"
+thiserror = "2"

--- a/crates/smt/src/errors.rs
+++ b/crates/smt/src/errors.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum SMTError {
+    #[error("Key {0} already exists")]
+    KeyAlreadyExist(String),
+    #[error("Key {0} does not exist")]
+    KeyDoesNotExist(String),
+    #[error("Parameter {name} must be a {expected_type}")]
+    InvalidParameterType { name: String, expected_type: String },
+    #[error("Invalid sibling index")]
+    InvalidSiblingIndex,
+}

--- a/crates/smt/src/lib.rs
+++ b/crates/smt/src/lib.rs
@@ -1,2 +1,5 @@
+pub mod errors;
 pub mod smt;
 mod utils;
+
+pub use errors::SMTError;

--- a/crates/smt/src/smt.rs
+++ b/crates/smt/src/smt.rs
@@ -2,34 +2,12 @@ use std::{collections::HashMap, str::FromStr};
 
 use num_bigint::BigInt;
 
+pub use crate::errors::SMTError;
 use crate::utils::{
     get_first_common_elements, get_index_of_last_non_zero_element, is_hexadecimal, key_to_path,
 };
 
 use std::fmt;
-
-#[derive(Debug, PartialEq)]
-pub enum SMTError {
-    KeyAlreadyExist(String),
-    KeyDoesNotExist(String),
-    InvalidParameterType(String, String),
-    InvalidSiblingIndex,
-}
-
-impl fmt::Display for SMTError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SMTError::KeyAlreadyExist(s) => write!(f, "Key {} already exists", s),
-            SMTError::KeyDoesNotExist(s) => write!(f, "Key {} does not exist", s),
-            SMTError::InvalidParameterType(p, t) => {
-                write!(f, "Parameter {} must be a {}", p, t)
-            },
-            SMTError::InvalidSiblingIndex => write!(f, "Invalid sibling index"),
-        }
-    }
-}
-
-impl std::error::Error for SMTError {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Node {
@@ -55,10 +33,10 @@ impl FromStr for Node {
         } else if is_hexadecimal(s) {
             Ok(Node::Str(s.to_string()))
         } else {
-            Err(SMTError::InvalidParameterType(
-                s.to_string(),
-                "BigInt or hexadecimal string".to_string(),
-            ))
+            Err(SMTError::InvalidParameterType {
+                name: s.to_string(),
+                expected_type: "BigInt or hexadecimal string".to_string(),
+            })
         }
     }
 }


### PR DESCRIPTION
## Description

This PR improves error handling across the IMT and SMT libraries by replacing ad-hoc or manually managed errors with explicit custom error types.

### What kind of change does this PR introduce?
Refactor / API improvement

### What is the current behavior?
In `imt`, several public methods returned `Result<_, &'static str>`, for example:
- `new`
- `insert`
- `update`
- `delete`
- `create_proof`

These methods returned plain string errors such as `"The tree is full"` or `"The leaf does not exist in this tree"` instead of structured error values. In `smt`, there was already an `SMTError` enum, but its `Display` and `std::error::Error` implementations were handwritten inside `smt.rs`.

### What is the new behavior?
This PR introduces dedicated error modules and typed error enums:
- `ImtError` in `crates/imt/src/errors.rs`
- `SMTError` in `crates/smt/src/errors.rs`

For `imt`, methods now return `Result<_, ImtError>` instead of `Result<_, &'static str>`, with concrete variants such as:
- `TooManyLeaves { got, arity, depth, max }`
- `TreeFull`
- `NotContained`

For `smt`, the existing error handling is cleaned up by moving `SMTError` into its own module and deriving `thiserror::Error`, replacing the manual `Display` and `Error` implementations. The `InvalidParameterType` variant is also changed to a named-field variant for clearer context.

### Why the previous version was problematic
Returning `Err("...")` from public APIs is less robust than using a dedicated error type. As described in [Rust By Example: Defining an error type](https://doc.rust-lang.org/rust-by-example/error/multiple_error_types/define_error_type.html?utm_source=chatgpt.com), custom error types are preferable when a function may fail in different ways, because they make failures explicit, easier to match on, and easier to extend with contextual information.

That applies directly here:
- a plain `&'static str` does not let callers reliably pattern-match on error variants,
- it cannot carry structured fields like `got`, `max`, `arity`, and `depth`,
- and it makes library APIs more brittle because callers may end up depending on message text instead of error semantics.

### Does this PR introduce a breaking change?
Yes.

This changes public return types in `imt` from `Result<_, &'static str>` to `Result<_, ImtError>`. Users who were matching on string errors or expecting `&'static str` will need to update their code to handle `ImtError` instead. The SMT refactor may also affect users importing or referencing `SMTError` from its previous location.

## Other information

This change makes the libraries more idiomatic and easier to maintain by using typed errors with `thiserror`, and by separating error definitions into dedicated modules. It also improves debuggability by attaching structured information to certain failures instead of only returning fixed strings.

## Checklist

- [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.rust/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.rust/blob/main/CODE_OF_CONDUCT.md).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings